### PR TITLE
mainブランチが保護されているため、ワークフローから直接pushできない問題に対応しました。

### DIFF
--- a/.github/workflows/update-contribution-badge.yml
+++ b/.github/workflows/update-contribution-badge.yml
@@ -1,0 +1,95 @@
+name: Update Contribution Badge
+
+on:
+  workflow_dispatch: # Allow manual trigger
+  pull_request:
+    types: [opened]
+    branches:
+      - main
+
+jobs:
+  update-badge:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Allow to push to the repository
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0 # Fetch all history for all branches and tags
+
+      - name: Calculate contribution
+        id: contribution
+        run: |
+          # Configure git to use the bot's identity
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Get total number of commits
+          TOTAL_COMMITS=$(git rev-list --count HEAD)
+
+          # Get number of commits by Jules
+          JULES_COMMITS=$(git log --author="google-labs-jules[bot]" --fixed-strings --oneline | wc -l)
+
+          # Calculate percentage
+          if [ "$TOTAL_COMMITS" -eq 0 ]; then
+            PERCENTAGE=0
+          else
+            PERCENTAGE=$((JULES_COMMITS * 100 / TOTAL_COMMITS))
+          fi
+          echo "Total commits: $TOTAL_COMMITS"
+          echo "Jules's commits: $JULES_COMMITS"
+          echo "Contribution: $PERCENTAGE%"
+          echo "percentage=$PERCENTAGE" >> $GITHUB_OUTPUT
+
+      - name: Update README.md
+        id: update_readme
+        run: |
+          BADGE_URL="https://img.shields.io/badge/Jules's%20contribution-${{ steps.contribution.outputs.percentage }}%25-715cd7"
+          BADGE_MARKDOWN="[![Jules's contribution]($BADGE_URL)](https://github.com/iusok3386/gcal-conference-editor/graphs/contributors)"
+
+          # Use a marker to replace the badge
+          START_MARKER="<!-- JULES-BADGE-START -->"
+          END_MARKER="<!-- JULES-BADGE-END -->"
+
+          # Replace the content between the markers
+          # Using awk for robust replacement
+          # The logic is: when start marker is found, print it, print the new content, and set a flag.
+          # When end marker is found, unset the flag and print the line.
+          # If the flag is not set, print the line.
+          NEW_README_CONTENT=$(awk -v start="$START_MARKER" -v end="$END_MARKER" -v new="$BADGE_MARKDOWN" '
+          BEGIN { in_block = 0 }
+          $0 == start {
+            print $0
+            print new
+            in_block = 1
+            next
+          }
+          $0 == end {
+            in_block = 0
+          }
+          in_block == 0 {
+            print $0
+          }
+          ' README.md)
+
+          # Write the new content back to README.md
+          echo "$NEW_README_CONTENT" > README.md
+
+          # Check if the file was changed
+          if git diff --quiet README.md; then
+            echo "readme_changed=false" >> $GITHUB_OUTPUT
+            echo "README.md not changed."
+          else
+            echo "readme_changed=true" >> $GITHUB_OUTPUT
+            echo "README.md changed."
+          fi
+
+      - name: Commit changes
+        if: steps.update_readme.outputs.readme_changed == 'true'
+        run: |
+          git add README.md
+          git commit -m "docs: update Jules's contribution badge [skip ci]"
+          git push

--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ limitations under the License.
 -->
 # Google Calendar 会議情報エディター
 
+[![clasp](https://img.shields.io/badge/built%20with-clasp-4285f4.svg)](https://github.com/google/clasp)
+[![Code Style: Google](https://img.shields.io/badge/code%20style-google-blueviolet.svg)](https://github.com/google/gts)
+[![Production Deployment](https://github.com/iusok3386/gcal-conference-editor/actions/workflows/production.yml/badge.svg)](https://github.com/iusok3386/gcal-conference-editor/deployments/production)
+<!-- JULES-BADGE-START -->
+![Jules's contribution](https://img.shields.io/badge/Jules's%20contribution-0%25-blue)
+<!-- JULES-BADGE-END -->
+
 このリポジトリは、Google Calendar の予定に含まれる会議情報 (`conferenceData`) を編集するための Web アプリケーションです。
 Google Meet 以外の任意の会議情報（例: YouTube Live, Discord）をカレンダーの予定に簡単に追加、編集、削除することができます。
 


### PR DESCRIPTION
ユーザーからの提案に基づき、ワークフローのトリガーを「mainブランチに対するプルリクエスト作成時」に一度だけ実行されるように変更しました。これにより、PR発行時にREADMEの貢献度バッジが更新され、ブランチ保護ルールを回避しつつ、貢献度を準リアルタイムで反映できます。

- ワークフローのトリガーを `on: pull_request: types: [opened]` に変更
- PRのソースブランチに変更をプッシュするため、`checkout`ステップに`ref`パラメータを再度追加